### PR TITLE
Fix linux pipeline.  

### DIFF
--- a/patch_python_package.py
+++ b/patch_python_package.py
@@ -16,7 +16,7 @@ with open("playwright-python/playwright/_repo_version.py", "w") as f:
     f.write(f"version = '{patchright_version}'")
 
 # Patching pyproject.toml
-with open("playwright-python/pyproject.toml", "r+") as f:
+with open("playwright-python/pyproject.toml", "r") as f:
     pyproject_source = toml.load(f)
 
     pyproject_source["project"]["name"] = "patchright"
@@ -35,8 +35,8 @@ with open("playwright-python/pyproject.toml", "r+") as f:
     pyproject_source["tool"]["setuptools"]["packages"] = ['patchright', 'patchright.async_api', 'patchright.sync_api', 'patchright._impl', 'patchright._impl.__pyinstaller']
     pyproject_source["tool"]["setuptools_scm"] = {'version_file': 'patchright/_repo_version.py'}
 
-    f.seek(0)
-    toml.dump(pyproject_source, f)
+    with open("playwright-python/pyproject.toml", "w") as f:
+        toml.dump(pyproject_source, f)
 
 
 # Patching setup.py


### PR DESCRIPTION
This commit resolves a parsing issue in the Linux pipeline due to the quoted key "Release notes" in pyproject.toml. The error occurred because TOML requires keys with spaces to be explicitly quoted. Adjustments were made to ensure compatibility while preserving the correct format.