### PR TITLE
Enhance networkidle calculations by excluding captcha and analytics requests

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -87,7 +87,7 @@ jobs:
             - api.funcaptcha.com (Arkose Labs)
             - client-api.arkoselabs.com (Arkose Labs)
 
-            Install: `pip install patchright@https://github.com/Hackerbone/patchright-python/releases/download/v${{ github.event.inputs.patchright_release }}/patchright-${{ github.event.inputs.patchright_release }}-py3-none-manylinux1_x86_64.whl`
+            Install: `pip install patchright@https://github.com/bugbasesecurity/patchright-python/releases/download/v${{ github.event.inputs.patchright_release }}/patchright-${{ github.event.inputs.patchright_release }}-py3-none-manylinux1_x86_64.whl`
           files: dist/*.whl
           draft: false
           prerelease: false

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,93 @@
+name: Build and Release Patched Patchright
+
+on:
+  workflow_dispatch:
+    inputs:
+      playwright_version:
+        description: 'Playwright-Python version tag (e.g. v1.56.0)'
+        required: true
+        default: 'v1.56.0'
+      patchright_release:
+        description: 'Patchright release version (e.g. 1.56.0)'
+        required: true
+        default: '1.56.0'
+
+permissions:
+  contents: write
+
+jobs:
+  build-wheels:
+    name: Build wheels
+    runs-on: ubuntu-latest
+    env:
+      patchright_release: ${{ github.event.inputs.patchright_release }}
+      playwright_version: ${{ github.event.inputs.playwright_version }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv sync --all-groups
+          git clone https://github.com/microsoft/playwright-python --branch "$playwright_version"
+          uv add -r playwright-python/local-requirements.txt --dev
+
+      - name: Patch Playwright-Python Package
+        run: uv run patch_python_package.py
+
+      - name: Format patched code
+        run: uvx ruff format playwright-python || true
+
+      - name: Build wheels
+        run: |
+          cd playwright-python
+          uv pip install -e .
+          for wheel in $(uv run setup.py --list-wheels); do
+            PLAYWRIGHT_TARGET_WHEEL=$wheel uv build --wheel
+          done
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: playwright-python/dist/*.whl
+
+  release:
+    name: Create GitHub Release
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.event.inputs.patchright_release }}
+          name: patchright v${{ github.event.inputs.patchright_release }}
+          body: |
+            Custom patchright build with networkidle captcha blacklisting.
+
+            Based on playwright-python ${{ github.event.inputs.playwright_version }}.
+
+            **Captcha domains excluded from networkidle:**
+            - challenges.cloudflare.com (Cloudflare Turnstile)
+            - google.com/recaptcha (reCAPTCHA)
+            - www.gstatic.com/recaptcha (reCAPTCHA assets)
+            - hcaptcha.com (hCaptcha)
+            - api.funcaptcha.com (Arkose Labs)
+            - client-api.arkoselabs.com (Arkose Labs)
+
+            Install: `pip install patchright@https://github.com/Hackerbone/patchright-python/releases/download/v${{ github.event.inputs.patchright_release }}/patchright-${{ github.event.inputs.patchright_release }}-py3-none-manylinux1_x86_64.whl`
+          files: dist/*.whl
+          draft: false
+          prerelease: false

--- a/patch_driver_networkidle.py
+++ b/patch_driver_networkidle.py
@@ -16,7 +16,7 @@ import re
 import sys
 from pathlib import Path
 
-CAPTCHA_PATTERNS_JS = '["challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha","hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com"]'
+CAPTCHA_PATTERNS_JS = '["challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha","hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com","google-analytics.com","googletagmanager.com","analytics.google.com","hotjar.com","fullstory.com","logrocket.com","mouseflow.com","clarity.ms","browser-intake-datadoghq.com","sentry.io","newrelic.com","nr-data.net","forter.com","/heartbeat","/keepalive","/keep-alive","/beacon"]'
 
 CAPTCHA_CHECK = f"""const _reqUrl = request.url();
     if ({CAPTCHA_PATTERNS_JS}.some(p => _reqUrl.includes(p)))

--- a/patch_driver_networkidle.py
+++ b/patch_driver_networkidle.py
@@ -1,0 +1,80 @@
+"""
+Patches the patchright driver's frames.js to exclude captcha polling requests
+from networkidle calculations.
+
+Run after the driver has been downloaded (after `pip install -e .` or `setup.py`):
+    python patch_driver_networkidle.py
+
+This modifies _inflightRequestStarted and _inflightRequestFinished to skip
+requests matching known captcha provider domains, following the same pattern
+as the existing _isFavicon exclusion in Playwright's source.
+
+Source: https://github.com/bugbasesecurity/patchright
+"""
+
+import re
+import sys
+from pathlib import Path
+
+CAPTCHA_PATTERNS_JS = '["challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha","hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com"]'
+
+CAPTCHA_CHECK = f"""const _reqUrl = request.url();
+    if ({CAPTCHA_PATTERNS_JS}.some(p => _reqUrl.includes(p)))
+      return;"""
+
+PATCH_MARKER = "// [patchright-networkidle-blacklist]"
+
+
+def find_frames_js() -> Path:
+    # Look in playwright-python/patchright/driver/ (post-patch build dir)
+    search_roots = [
+        Path("playwright-python/patchright/driver"),
+        Path("playwright-python/playwright/driver"),
+    ]
+
+    for root in search_roots:
+        if root.exists():
+            candidates = list(root.rglob("**/server/frames.js"))
+            if candidates:
+                return candidates[0]
+
+    # Fallback: search from current dir
+    candidates = list(Path(".").rglob("**/driver/package/lib/server/frames.js"))
+    if candidates:
+        return candidates[0]
+
+    print("ERROR: Could not find frames.js in driver", file=sys.stderr)
+    sys.exit(1)
+
+
+def patch_method(code: str, method_name: str) -> str:
+    pattern = rf'({method_name}\(request\) \{{[^}}]*?if \(request\._isFavicon\)\s*return;)'
+    match = re.search(pattern, code, re.DOTALL)
+
+    if not match:
+        print(f"ERROR: Could not find {method_name} with _isFavicon check", file=sys.stderr)
+        sys.exit(1)
+
+    original = match.group(1)
+    patched = original + f"\n    {PATCH_MARKER}\n    {CAPTCHA_CHECK}"
+    return code.replace(original, patched, 1)
+
+
+def main():
+    frames_js = find_frames_js()
+    code = frames_js.read_text()
+
+    if PATCH_MARKER in code:
+        print(f"Already patched: {frames_js}")
+        return
+
+    code = patch_method(code, "_inflightRequestStarted")
+    code = patch_method(code, "_inflightRequestFinished")
+
+    frames_js.write_text(code)
+    print(f"Patched: {frames_js}")
+    print(f"Captcha domains excluded from networkidle: {CAPTCHA_PATTERNS_JS}")
+
+
+if __name__ == "__main__":
+    main()

--- a/patch_python_package.py
+++ b/patch_python_package.py
@@ -588,9 +588,9 @@ with open("playwright-python/setup.py") as f:
 NETWORKIDLE_PATCH_CODE = '''
 import re as _re
 
-_CAPTCHA_PATTERNS_JS = '["challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha","hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com"]'
+_EXCLUDED_PATTERNS_JS = '["challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha","hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com","google-analytics.com","googletagmanager.com","analytics.google.com","hotjar.com","fullstory.com","logrocket.com","mouseflow.com","clarity.ms","browser-intake-datadoghq.com","sentry.io","newrelic.com","nr-data.net","forter.com","/heartbeat","/keepalive","/keep-alive","/beacon"]'
 _PATCH_MARKER = '// [patchright-networkidle-blacklist]'
-_CAPTCHA_CHECK = f'const _reqUrl = request.url();\\n    if ({_CAPTCHA_PATTERNS_JS}.some(p => _reqUrl.includes(p)))\\n      return;'
+_CAPTCHA_CHECK = f'const _reqUrl = request.url();\\n    if ({_EXCLUDED_PATTERNS_JS}.some(p => _reqUrl.includes(p)))\\n      return;'
 
 def _patch_networkidle_blacklist(driver_root):
     for dirpath, _, filenames in os.walk(driver_root):

--- a/patch_python_package.py
+++ b/patch_python_package.py
@@ -51,7 +51,7 @@ with open("playwright-python/setup.py") as f:
 
         # Modify url
         if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.targets[0], ast.Name):
-            if node.targets[0].id == "url" and node.value.value == "https://cdn.playwright.dev/builds/driver/":
+            if node.targets[0].id == "url" and node.value.value in ("https://cdn.playwright.dev/builds/driver/", "https://playwright.azureedge.net/builds/driver/"):
                 node.value = ast.JoinedStr(
                     values=[
                         ast.Constant(value='https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/releases/download/v'),
@@ -578,6 +578,56 @@ for python_file in glob.glob("playwright-python/playwright/**.py") + glob.glob("
                     node.value = ast.parse(unparsed_attribute.replace("playwright", "patchright", 1)).body[0].value
 
         patch_file(python_file, file_tree)
+
+# Patching setup.py to add networkidle captcha blacklisting
+# This injects a function that patches the driver's frames.js after extraction
+# to exclude captcha polling requests from networkidle calculations
+with open("playwright-python/setup.py") as f:
+    setup_code = f.read()
+
+NETWORKIDLE_PATCH_CODE = '''
+import re as _re
+
+_CAPTCHA_PATTERNS_JS = '["challenges.cloudflare.com","google.com/recaptcha","www.gstatic.com/recaptcha","hcaptcha.com","api.funcaptcha.com","client-api.arkoselabs.com"]'
+_PATCH_MARKER = '// [patchright-networkidle-blacklist]'
+_CAPTCHA_CHECK = f'const _reqUrl = request.url();\\n    if ({_CAPTCHA_PATTERNS_JS}.some(p => _reqUrl.includes(p)))\\n      return;'
+
+def _patch_networkidle_blacklist(driver_root):
+    for dirpath, _, filenames in os.walk(driver_root):
+        for f in filenames:
+            if f == 'frames.js' and 'server' in dirpath:
+                fpath = os.path.join(dirpath, f)
+                code = open(fpath).read()
+                if _PATCH_MARKER in code:
+                    return
+                for method in ['_inflightRequestStarted', '_inflightRequestFinished']:
+                    pat = _re.compile(rf'({method}\\(request\\) \\{{[^}}]*?if \\(request\\._isFavicon\\)\\s*return;)', _re.DOTALL)
+                    m = pat.search(code)
+                    if m:
+                        code = code.replace(m.group(1), m.group(1) + f'\\n    {_PATCH_MARKER}\\n    {_CAPTCHA_CHECK}', 1)
+                open(fpath, 'w').write(code)
+                print(f'Patched networkidle blacklist: {fpath}')
+                return
+'''
+
+# Insert the function definition near the top (after imports)
+# and add calls after each extractall in _build_wheel and _download_and_extract_local_driver
+setup_code = NETWORKIDLE_PATCH_CODE + setup_code
+
+# Add _patch_networkidle_blacklist call after extraction in _build_wheel
+setup_code = setup_code.replace(
+    "extractall(zip, f\"driver/{wheel_bundle['zip_name']}\")",
+    "extractall(zip, f\"driver/{wheel_bundle['zip_name']}\")\n        _patch_networkidle_blacklist(f\"driver/{wheel_bundle['zip_name']}\")"
+)
+
+# Add _patch_networkidle_blacklist call after extraction in _download_and_extract_local_driver
+setup_code = setup_code.replace(
+    "extractall(zip, 'patchright/driver')",
+    "extractall(zip, 'patchright/driver')\n        _patch_networkidle_blacklist('patchright/driver')"
+)
+
+with open("playwright-python/setup.py", "w") as f:
+    f.write(setup_code)
 
 # Rename the Package Folder to Patchright
 os.rename("playwright-python/playwright", "playwright-python/patchright")


### PR DESCRIPTION
- Added a patch on networkidle calculation to ignore captcha and analytics requests
- wait for networkidle is used as a wait until the page has become responsive enough to continue next steps but analytics requests / random captcha polls lead to it being timed-out - this patch fixes it.
- networkidle -> 500ms of idle network activity (but polling requests might be 150ms apart which disrupt the flow)

Addtionally:
- If this implementation can be improved do let me know, will issue that patch and update!

