### PR TITLE
bugfix: match pyproject.toml to package

### DIFF
--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -1,0 +1,35 @@
+# Only for test Runs, does not relate to actual Patchright package
+[project]
+name = "patchright-tests"
+version = "1.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "patchright>=1.59.1",
+]
+
+[tool.pytest.ini_options]
+addopts = "-Wall -rsx" #  -s
+markers = [
+    "skip_browser",
+    "only_browser",
+    "skip_platform",
+    "only_platform"
+]
+junit_family = "xunit2"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
+
+[dependency-groups]
+dev = [
+    "autobahn>=25.12.2",
+    "pillow>=12.0.0",
+    "pixelmatch>=0.3.0",
+    "pyopenssl>=25.3.0",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-timeout>=2.4.0",
+    "requests>=2.32.5",
+    "twisted>=25.5.0",
+    "toml>=0.10.0"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,35 +1,8 @@
-# Only for test Runs, does not relate to actual Patchright package
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
-name = "patchright-tests"
-version = "1.0.0"
-requires-python = ">=3.11"
-dependencies = [
-    "patchright>=1.59.1",
-]
-
-[tool.pytest.ini_options]
-addopts = "-Wall -rsx" #  -s
-markers = [
-    "skip_browser",
-    "only_browser",
-    "skip_platform",
-    "only_platform"
-]
-junit_family = "xunit2"
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
-asyncio_default_test_loop_scope = "session"
-
-[dependency-groups]
-dev = [
-    "autobahn>=25.12.2",
-    "pillow>=12.0.0",
-    "pixelmatch>=0.3.0",
-    "pyopenssl>=25.3.0",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
-    "pytest-timeout>=2.4.0",
-    "requests>=2.32.5",
-    "twisted>=25.5.0",
-    "toml>=0.10.0"
-]
+name = "patchright"
+version = "1.61.0"
+description = "A patched drop-in replacement for Playwright"


### PR DESCRIPTION
Moves the `patchright-test` definition to `examples` and adds a new `pyproject.toml` just for `patchright-python`.

Tested by building the package.

Closes #119